### PR TITLE
Fix compatibility for PHP 7

### DIFF
--- a/src/CacheWarmup/CacheWarmup.php
+++ b/src/CacheWarmup/CacheWarmup.php
@@ -167,7 +167,14 @@ class CacheWarmup extends \Backend implements \executable
 
             // Display the pages
             for ($i=0, $c=count($arrPages); $i<$c; $i++) {
-                $strBuffer .= '<span class="page_url" data-url="' . $arrPages[$i] . '#' . $rand . $i . '">' . \String::substr($arrPages[$i], 100) . '</span><br>';
+                // Use StringUtil class when used Contao version is minimum 3.5.1
+                // see https://github.com/contao/core-bundle/issues/309
+                if (version_compare(VERSION .'.'.BUILD, '3.5.1', '<')) {
+                    $strBuffer .= '<span class="page_url" data-url="' . $arrPages[$i] . '#' . $rand . $i . '">' . \String::substr($arrPages[$i], 100) . '</span><br>';
+                } else {
+                    $strBuffer .= '<span class="page_url" data-url="' . $arrPages[$i] . '#' . $rand . $i . '">' . \StringUtil::substr($arrPages[$i], 100) . '</span><br>';
+                }
+
                 unset($arrPages[$i]); // see #5681
             }
 


### PR DESCRIPTION
Use Contao's `StringUtil` class if available and be compatible with PHP7. 
See https://github.com/contao/core-bundle/issues/309
